### PR TITLE
Updated variable name to avoid confusion

### DIFF
--- a/components/ManualHeader.js
+++ b/components/ManualHeader.js
@@ -18,14 +18,14 @@ export default function ManualHeader() {
             // enableWeb3({provider: window.localStorage.getItem("connected")}) // add walletconnect
         }
     }, [isWeb3Enabled])
-    // no array, run on every render 
+    // no array, run on every render
     // empty array, run once
     // dependency array, run when the stuff in it changesan
 
     useEffect(() => {
-        Moralis.onAccountChanged((account) => {
-            console.log(`Account changed to ${account}`)
-            if (account == null) {
+        Moralis.onAccountChanged((newAccount) => {
+            console.log(`Account changed to ${newAccount}`)
+            if (newAccount == null) {
                 window.localStorage.removeItem("connected")
                 deactivateWeb3()
                 console.log("Null Account found")


### PR DESCRIPTION
Using the variable "account" on the Moralis.onAccountChange event callback parameter while there's also the same variable "account" defined from the destructured object returned by useMoralis() (line 8-9), might confuse readers / new code leaners.